### PR TITLE
Issue17 - Generation of SSL/DKIM keys on first run

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -78,6 +78,9 @@ RUN sed -i '/^Foreground /c Foreground true' /etc/clamav/clamd.conf \
     && sed -i 's/SHOWWARNING[ \t]*=.*/SHOWWARNING=false/g' /etc/tmpreaper.conf \
     && install -o amavis -g amavis -m 750 -d /var/lib/amavis/.spamassassin \
     && install -o amavis -g amavis -m 640 -T /usr/share/spamassassin/user_prefs.template /var/lib/amavis/.spamassassin/user_prefs
+    && rm -f /etc/ssl/private/iRedMail.key \
+    && rm -f /etc/ssl/certs/iRedMail.crt \
+    && rm -f /var/lib/dkim/DOMAIN.pem
 
 # Prepare for the first run
 RUN tar jcf /root/mysql.tar.bz2 /var/lib/mysql && rm -rf /var/lib/mysql \

--- a/mysql/rc.local
+++ b/mysql/rc.local
@@ -23,4 +23,8 @@ if [ ! -e /opt/iredmail/.cv ]; then
   echo IREDAPD_DB_PASSWD="$(openssl rand -hex 32)" >> /opt/iredmail/.cv
 fi
 
+if [ ! -e /etc/ssl/private/iRedMail.key ] || [ ! -e /etc/ssl/certs/iRedMail.crt ]; then
+  (cd /etc/ssl && . /opt/iredmail/tools/generate_ssl_keys.sh)
+fi
+
 exit 0

--- a/mysql/services/amavis.sh
+++ b/mysql/services/amavis.sh
@@ -7,14 +7,14 @@ done
 
 
 echo "*** Starting amavis.."
-if [ ! -z ${DOMAIN} ]; then 
-    sed -i "s/DOMAIN/${DOMAIN}/g" /etc/amavis/conf.d/50-user
-    mv /var/lib/dkim/DOMAIN.pem /var/lib/dkim/${DOMAIN}.pem
+sed -i "s/DOMAIN/${DOMAIN}/g" /etc/amavis/conf.d/50-user
+sed -i "s/HOSTNAME/${HOSTNAME}/g" /etc/amavis/conf.d/50-user
+if [ ! -e /var/lib/dkim/${DOMAIN}.pem ]; then
+    amavisd-new genrsa /var/lib/dkim/${DOMAIN}.pem 1024
+    chown amavis:amavis /var/lib/dkim/${DOMAIN}.pem
+    chmod 0400 /var/lib/dkim/${DOMAIN}.pem
 fi
 
-if [ ! -z ${HOSTNAME} ]; then 
-    sed -i "s/HOSTNAME/${HOSTNAME}/g" /etc/amavis/conf.d/50-user
-fi;
 
 # Update password
 . /opt/iredmail/.cv


### PR DESCRIPTION
This pull request addresses lejmr/iredmail-docker#17.  In summary 'Dockerfile' is amended to delete the keys that iRedMail.sh creates during the setup process and 'rc.local' is amended to test for the existence of these call files and call 'generate_ssl_keys.sh' if they do not exists.  This has been tested by comparing container keys on multiple containers using MD5SUM, confirming that they are different (and also that prior to this commit they were the same).