### PR TITLE
Issue21 - Changes to WOWorkersCount and PREFORK are unecessary

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -9,7 +9,6 @@ ARG ADMINER_VERSION=4.3.1
 ARG DOMAIN=DOMAIN
 ARG HOSTNAME=HOSTNAME
 ARG TIMEZONE=Europe/Prague
-ARG SOGO_WORKERS=2
 
 ### Installation
 # Prerequisites
@@ -18,24 +17,24 @@ RUN echo "APT::Install-Recommends 0;" >> /etc/apt/apt.conf.d/01-no-recommends \
     && echo "APT::Install-Suggests 0;" >> /etc/apt/apt.conf.d/01-no-recommends \
     && echo $TIMEZONE > /etc/timezone \
     && apt-get -q update \
-    &&  apt-get upgrade -y \
+    && apt-get upgrade -y \
     && apt-get install -y -q \
-      apt-utils \
+       apt-utils \
     && apt-get install -y -q \
-      wget \
-      bzip2 \
-      iptables \
-      openssl \
-      mysql-server \ 
-      netcat \
-      memcached \
+       wget \
+       bzip2 \
+       iptables \
+       openssl \
+       mysql-server \
+       netcat \
+       memcached \
     && apt-get autoremove -y -q \
-    && apt-get clean -y -q \ 
+    && apt-get clean -y -q \
     && echo $DOMAIN > /etc/mailname \
     && echo $HOSTNAME > /opt/hostname \
     && mv /bin/uname /bin/uname_ \
     && mv /bin/hostname /bin/hostname_
-    
+
 COPY ./uname /bin/uname
 COPY ./hostname /bin/hostname
 
@@ -49,7 +48,7 @@ RUN wget -O - https://bitbucket.org/zhb/iredmail/downloads/iRedMail-"${IREDMAIL_
 COPY ./config-gen /opt/iredmail/config-gen
 RUN sh ./config-gen $HOSTNAME $DOMAIN > ./config
 
-# Initiate automatic installation process 
+# Initiate automatic installation process
 RUN sed s/$(hostname_)/$(cat /opt/hostname | xargs echo -n).$(cat /etc/mailname | xargs echo -n)/ /etc/hosts > /tmp/hosts_ \
     && cat /tmp/hosts_ > /etc/hosts \
     && rm /tmp/hosts_ \
@@ -69,12 +68,10 @@ RUN sed s/$(hostname_)/$(cat /opt/hostname | xargs echo -n).$(cat /etc/mailname 
       AUTO_CLEANUP_RESTART_POSTFIX=n \
       bash iRedMail.sh \
     && apt-get autoremove -y -q \
-    && apt-get clean -y -q  
+    && apt-get clean -y -q
 
 ### Final configuration
 RUN . ./config \
-    && sed -i 's/PREFORK=.*$'/PREFORK=$SOGO_WORKERS/ /etc/default/sogo \
-    && sed -i 's/WOWorkersCount.*$'/WOWorkersCount=$SOGO_WORKERS\;/ /etc/sogo/sogo.conf \
     && sed -i '/^Foreground /c Foreground true' /etc/clamav/clamd.conf \
     && sed -i '/init.d/c pkill -sighup clamd' /etc/logrotate.d/clamav-daemon \
     && sed -i '/^Foreground /c Foreground true' /etc/clamav/freshclam.conf \
@@ -122,3 +119,5 @@ RUN apt-get purge -y -q dialog apt-utils augeas-tools \
 # Apache: 80/tcp, 443/tcp Postfix: 25/tcp, 587/tcp
 # Dovecot: 110/tcp, 143/tcp, 993/tcp, 995/tcp
 EXPOSE 80 443 25 587 110 143 993 995
+
+ENV SOGO_WORKERS=2

--- a/mysql/services/sogo.sh
+++ b/mysql/services/sogo.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Wait until Dovecot is started
-while ! nc -z localhost 993; do   
+while ! nc -z localhost 993; do
   sleep 1
 done
 
@@ -14,18 +14,11 @@ NAME=sogo
 PIDFILE=/var/run/$NAME/$NAME.pid
 LOGFILE=/var/log/$NAME/$NAME.log
 
-# Overwrite prefork from attribut
-if [ ! -z ${SOGO_WORKERS} ]; then
-    if [ $SOGO_WORKERS -ne $PREFORK ]; then
-        PREFORK=$SOGO_WORKERS
-    fi;
-fi;
-
 # Format options
-DAEMON_OPTS="-WOWorkersCount $PREFORK -WOPidFile $PIDFILE -WOLogFile $LOGFILE -WONoDetach YES"
+DAEMON_OPTS="-WOWorkersCount $SOGO_WORKERS -WOPidFile $PIDFILE -WOLogFile $LOGFILE -WONoDetach YES"
 
 # Manually change timezone based on attribut
-if [ ! -z ${TIMEZONE} ]; then 
+if [ ! -z ${TIMEZONE} ]; then
     DAEMON_OPTS="$DAEMON_OPTS -WSOGoTimeZone $TIMEZONE"
 fi
 


### PR DESCRIPTION
This pull request implement the changes suggested in lejmr/iredmail-docker#21.  The patching of /etc/default/sogo and /etc/sogo/sogo.conf in the dockerfile is removed and sogo.sh is modified to pass SOGO_WORKERS directly to the daemon.  This has been checked and found to create the correct number of worker threads as set by SOGO_WORKERS.