### PR TITLE
Issue24 - Annoying CRON emails that appear every time a container is recreated

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -75,7 +75,10 @@ RUN . ./config \
     && sed -i '/^Foreground /c Foreground true' /etc/clamav/clamd.conf \
     && sed -i '/init.d/c pkill -sighup clamd' /etc/logrotate.d/clamav-daemon \
     && sed -i '/^Foreground /c Foreground true' /etc/clamav/freshclam.conf \
-    && sed -i 's/^bind-address/#bind-address/' /etc/mysql/mysql.conf.d/mysqld.cnf
+    && sed -i 's/^bind-address/#bind-address/' /etc/mysql/mysql.conf.d/mysqld.cnf \
+    && sed -i 's/SHOWWARNING[ \t]*=.*/SHOWWARNING=false/g' /etc/tmpreaper.conf \
+    && install -o amavis -g amavis -m 750 -d /var/lib/amavis/.spamassassin \
+    && install -o amavis -g amavis -m 640 -T /usr/share/spamassassin/user_prefs.template /var/lib/amavis/.spamassassin/user_prefs
 
 # Prepare for the first run
 RUN tar jcf /root/mysql.tar.bz2 /var/lib/mysql && rm -rf /var/lib/mysql \


### PR DESCRIPTION
This addresses lejmr/iredmail-docker#24. Modify Dockerfile to patch tmpreaper.conf to suppress the CRON warning.  Generate /var/lib/amavis/.spamassassin/user_prefs to stop the CRON job from complaining about having to create one.