### PR TITLE
remove legacy clutter and add missing quirks to fix the build

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -37,13 +37,15 @@ RUN wget -O - https://bitbucket.org/zhb/iredmail/downloads/iRedMail-"${IREDMAIL_
 # Generate configuration file
 COPY ./config-gen /opt/iredmail/config-gen
 RUN sh ./config-gen HOSTNAME DOMAIN > ./config
+RUN mkdir /var/run/mysql && chown mysql:mysql /var/run/mysql 
 
 # Initiate automatic installation process
-RUN sed s/$(hostname_)/$(cat /opt/hostname | xargs echo -n).$(cat /etc/mailname | xargs echo -n)/ /etc/hosts > /tmp/hosts_ \
+RUN sed s/$(hostname)/$HOSTNAME.$DOMAIN/ /etc/hosts > /tmp/hosts_ \
     && cat /tmp/hosts_ > /etc/hosts \
     && rm /tmp/hosts_ \
     && echo $HOSTNAME > /etc/hostname \
-    && sleep 5;service mysql start \
+    && chown mysql:mysql -R /var/lib/mysql \
+    && service mysql start \
     && IREDMAIL_DEBUG='NO' \
        IREDMAIL_HOSTNAME="HOSTNAME.DOMAIN" \
        CHECK_NEW_IREDMAIL='NO' \

--- a/mysql/services/postfix.sh
+++ b/mysql/services/postfix.sh
@@ -106,6 +106,8 @@ trap "trap_term_signal" TERM
 
 echo "*** Starting postfix.."
 touch /var/tmp/postfix.run
+# missing from latest images for some reason
+mkdir /var/spool/postfix/hold
 chown -R postfix /var/spool/postfix
 /usr/lib/postfix/sbin/master -c /etc/postfix -d &
 pid=$!


### PR DESCRIPTION
this is a trivial fix to some problems i found when attempting to execute a build, namely:

- hostname detection was relying on hacks that were removed
- /var/lib/mysql forced ownership by mysql
- postfix's hold queue was missing

